### PR TITLE
Improved Dockerfile (composer and install-php-extensions) to reduce image size and build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,6 @@ RUN apt-get -qq update && \
         # For Imagick extension
         imagemagick \
         libmagickwand-dev \
-        # libmemcached-dev # Only if you install the memcached PHP extension
-        # libmcrypt-dev # Obsolete, remove unless specifically needed for very old code
     # Cleanup apt cache
     && apt-get clean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,32 +17,46 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 RUN ln -sf /dev/stdout /var/log/apache2/access.log && \
     ln -sf /dev/stderr /var/log/apache2/error.log
 
-RUN apt-get -qq update && apt-get -qq -y upgrade
-RUN apt-get -qq update && apt-get -qq -y --no-install-recommends install \
-    unzip \
-    libfreetype6-dev \
-    libjpeg62-turbo-dev \
-    libmcrypt-dev \
-    libpng-dev \
-    libjpeg-dev \
-    libmemcached-dev \
-    zlib1g-dev \
-    imagemagick \
-    libmagickwand-dev \
-    wget \
-    ghostscript \
-    poppler-utils \
-    libsodium-dev \
-    libicu-dev
+# Install system dependencies required by PHP extensions and Omeka-S
+RUN apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install \
+        # Utils needed later
+        unzip \
+        wget \
+        ghostscript \
+        poppler-utils \
+        # PHP Extension Runtime/Build-time Libs (-dev packages needed for compilation)
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        # libjpeg-dev # Likely redundant with libjpeg62-turbo-dev
+        libpng-dev \
+        zlib1g-dev \
+        libicu-dev \
+        libsodium-dev \
+        # For Imagick extension
+        imagemagick \
+        libmagickwand-dev \
+        # libmemcached-dev # Only if you install the memcached PHP extension
+        # libmcrypt-dev # Obsolete, remove unless specifically needed for very old code
+    # Cleanup apt cache
+    && apt-get clean
 
-# Install the PHP extensions we need
-RUN docker-php-ext-configure gd --with-jpeg=/usr/include/ --with-freetype=/usr/include/
-RUN docker-php-ext-install -j$(nproc) iconv pdo pdo_mysql mysqli gd
-RUN yes | pecl install imagick && docker-php-ext-enable imagick 
+# Install Composer
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-# Support for more languages, e.g. for date formatting and month names
-RUN docker-php-ext-configure intl
-RUN docker-php-ext-install intl
+# Install PHP extension installer tool
+ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+
+# Install PHP extensions using the tool
+# It will handle installing/removing temporary build dependencies (like build-essential)
+RUN install-php-extensions \
+    gd \
+    iconv \
+    pdo \
+    pdo_mysql \
+    mysqli \
+    imagick \
+    intl
 
 # Add the Omeka-S PHP code
 # Latest Omeka version, check: https://omeka.org/s/download/


### PR DESCRIPTION
This pull request updates the `Dockerfile` to optimize the installation of system and PHP dependencies, improve maintainability, and reduce image size.

### Key changes:
- Composer is now added directly from the latest Composer image.
- PHP extensions are installed using the `[install-php-extensions](https://github.com/mlocati/docker-php-extension-installer/)` tool (`ADD --chmod=0755 ...`), replacing manual `docker-php-ext-configure` and `docker-php-ext-install` commands for a cleaner and more efficient setup.
- System package installation has been reorganized, removing obsolete or redundant libraries (`libjpeg-dev`, `libmcrypt-dev`, `libmemcached-dev`).
- Apt cache cleanup added to minimize final image size.

The build time has been reduced from **30 minutes** to **20 minutes**.
The base Docker image size has been reduced from **1.27 GB** to **991 MB**.