### PR TITLE
Add xsl PHP extension to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,8 @@ RUN install-php-extensions \
     pdo_mysql \
     mysqli \
     imagick \
-    intl
+    intl \
+    xsl
 
 # Add the Omeka-S PHP code
 # Latest Omeka version, check: https://omeka.org/s/download/


### PR DESCRIPTION
This pull request (thanks to @fmateos) updates the `Dockerfile` to include the `xsl` PHP extension, which is required by some Omeka S modules that rely on XSLT transformations.

### 📌 Justification

The [BulkImport](https://github.com/Daniel-KM/Omeka-S-module-BulkImport) module by Daniel-KM requires XSL processing capabilities to import XML-based metadata using XSLT 1.0 stylesheets. Including the `xsl` extension ensures compatibility and avoids runtime errors during import operations.

> ℹ️ XSLT 1.0 is supported via `php-xsl`, while XSLT 2.0 support can be configured separately with Saxon as described in the module documentation.