### PR TITLE
Automatically configure Omeka S at container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get -qq update && \
         wget \
         ghostscript \
         poppler-utils \
+        netcat-openbsd \
         # PHP Extension Runtime/Build-time Libs (-dev packages needed for compilation)
         libfreetype6-dev \
         libjpeg62-turbo-dev \
@@ -94,5 +95,8 @@ VOLUME /var/www/html/volume/
 
 # Overwrite the original Docker PHP entrypoint
 COPY docker-php-entrypoint /usr/local/bin/
+
+# Copy the automatic installation script
+COPY install_cli.php /var/www/html/
 
 RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ You can configure the database connection using environment variables instead of
 | PHP_UPLOAD_MAX_FILESIZE | Max upload file size (e.g. 64M)        | 128M         |
 | PHP_POST_MAX_SIZE       | Max post size (e.g. 64M)               | 128M         |
 | PHP_MAX_EXECUTION_TIME  | Max script execution time (seconds)    | 300          |
+| OMEKA_ADMIN_EMAIL       | Email for the first Omeka S admin user |              |
+| OMEKA_ADMIN_NAME        | Name of the first admin user           |              |
+| OMEKA_ADMIN_PASSWORD    | Password for the admin user            |              |
+| OMEKA_SITE_TITLE        | Public title of the Omeka S site       |              |
+| OMEKA_TIMEZONE          | Installation timezone (optional)       | UTC          |
+| OMEKA_LOCALE            | Interface locale (optional)            | en_US        |
+
+> If the `OMEKA_ADMIN_` variables (`EMAIL`, `NAME`, `PASSWORD`, `SITE_TITLE`) are not set, Omeka S will not be configured automatically at startup.
 
 ## Docker Hub
 

--- a/docker-compose_local_example.yml
+++ b/docker-compose_local_example.yml
@@ -26,7 +26,10 @@ services:
       PHP_UPLOAD_MAX_FILESIZE: 64M
       PHP_POST_MAX_SIZE: 64M
       PHP_MAX_EXECUTION_TIME: 300
-
+      OMEKA_ADMIN_EMAIL: admin@example.com
+      OMEKA_ADMIN_NAME: "Site Administrator"
+      OMEKA_ADMIN_PASSWORD: supersecret
+      OMEKA_SITE_TITLE: "My Omeka Site"
     volumes:
       - omekas:/var/www/html/volume:Z
 

--- a/docker-compose_traefik_example.yml
+++ b/docker-compose_traefik_example.yml
@@ -67,6 +67,10 @@ services:
       PHP_UPLOAD_MAX_FILESIZE: 64M
       PHP_POST_MAX_SIZE: 64M
       PHP_MAX_EXECUTION_TIME: 300
+      OMEKA_ADMIN_EMAIL: admin@example.com
+      OMEKA_ADMIN_NAME: "Site Administrator"
+      OMEKA_ADMIN_PASSWORD: supersecret
+      OMEKA_SITE_TITLE: "My Omeka Site"
     networks:
       - network1
     links:

--- a/docker-php-entrypoint
+++ b/docker-php-entrypoint
@@ -1,6 +1,19 @@
 #!/bin/sh
 set -e
 
+# Function to check the availability of a database
+check_db_availability() {
+    local db_host="$1"
+    local db_port="$2"
+    echo "Waiting for $db_host:$db_port to be ready..."
+    while ! nc -w 1 "$db_host" "$db_port" > /dev/null 2>&1; do
+        # Show some progress
+        echo -n '.'
+        sleep 1
+    done
+    echo "\n\nGreat, $db_host is ready!"
+}
+
 # Set php.ini and .htaccess according to APPLICATION_ENV
 if [ "$APPLICATION_ENV" = "development" ]; then
     cp "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
@@ -99,6 +112,35 @@ PHP_CUSTOM_INI="$PHP_INI_DIR/conf.d/docker-php-custom.ini"
 
 echo "[Entrypoint] Using custom PHP configuration:"
 cat "$PHP_CUSTOM_INI"
+
+# Install Omeka S only if required environment variables are set and not empty
+if [ -n "${OMEKA_ADMIN_EMAIL:-}" ] && [ -n "${OMEKA_ADMIN_NAME:-}" ] && \
+   [ -n "${OMEKA_ADMIN_PASSWORD:-}" ] && [ -n "${OMEKA_SITE_TITLE:-}" ]; then
+  echo "[Entrypoint] Installing Omeka S via CLI..."
+
+  # If MYSQL_HOST is set, check the availability of the database
+  if [ -n "$MYSQL_HOST" ]; then
+      check_db_availability "$MYSQL_HOST" 3306
+  fi
+
+  CMD="php install_cli.php \
+    --email=\"$OMEKA_ADMIN_EMAIL\" \
+    --name=\"$OMEKA_ADMIN_NAME\" \
+    --password=\"$OMEKA_ADMIN_PASSWORD\" \
+    --title=\"$OMEKA_SITE_TITLE\""
+
+  if [ -n "${OMEKA_TIMEZONE:-}" ]; then
+    CMD="$CMD --timezone=\"$OMEKA_TIMEZONE\""
+  fi
+
+  if [ -n "${OMEKA_LOCALE:-}" ]; then
+    CMD="$CMD --locale=\"$OMEKA_LOCALE\""
+  fi
+
+  eval "$CMD"
+else
+  echo "[Entrypoint] Skipping Omeka S install: missing required environment variables (OMEKA_ADMIN_EMAIL, OMEKA_ADMIN_NAME, OMEKA_ADMIN_PASSWORD, OMEKA_SITE_TITLE)"
+fi
 
 # Run the original Docker PHP entrypoint (ref. file https://github.com/docker-library/php/blob/master/8.2/bookworm/apache/docker-php-entrypoint)
 # first argument is `-f` or another option

--- a/install_cli.php
+++ b/install_cli.php
@@ -1,0 +1,98 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Omeka S CLI installer
+ *
+ * This script performs the initial Omeka S installation using command-line arguments.
+ * It is typically invoked automatically at container startup if environment variables
+ * like OMEKA_ADMIN_EMAIL, OMEKA_ADMIN_NAME, etc. are provided.
+ *
+ * The script is idempotent: if Omeka S is already installed (based on DB tables),
+ * it will exit safely without attempting to reinstall.
+ *
+ * Usage (example):
+ *   php install_cli.php --email=admin@example.com --name="Admin" --password=secret --title="My Site"
+ *
+ * Optional:
+ *   --timezone=Atlantic/Canary   (default: UTC)
+ *   --locale=es                  (default: en_US)
+ */
+
+if (PHP_SAPI !== 'cli') {
+    echo "CLI only\n";
+    exit(1);
+}
+
+$options = getopt('', [
+    'email:',
+    'name:',
+    'password:',
+    'title:',
+    'timezone::',
+    'locale::',
+]);
+if (empty($options['email']) || empty($options['name'])
+    || empty($options['password']) || empty($options['title'])
+) {
+    echo "Usage:\n";
+    echo "  php install_cli.php --email=EMAIL --name=NAME --password=PASS "
+       . "--title=TITLE [--timezone=UTC] [--locale=en_US]\n";
+    exit(1);
+}
+
+require 'bootstrap.php';
+$app = \Laminas\Mvc\Application::init(
+    require 'application/config/application.config.php'
+);
+$services = $app->getServiceManager();
+
+// Get the raw DB connection from Omeka
+/** @var \Laminas\Db\Adapter\AdapterInterface $connection */
+$connection = $services->get('Omeka\Connection');
+
+// Check if the 'api_key' table already exists; if so, assume installed
+$found = $connection->fetchOne('SHOW TABLES LIKE ?', ['api_key']);
+if ($found) {
+    echo "Omeka S is already installed.\n";
+    exit(0);
+}
+
+$status = $services->get('Omeka\\Status');
+if ($status->isInstalled()) {
+    echo "Omeka S is already installed.\n";
+    exit(0);
+}
+
+$installer = $services->get('Omeka\\Installer');
+
+$installer->registerVars(
+    Omeka\Installation\Task\CreateFirstUserTask::class,
+    [
+        'email' => $options['email'],
+        'name'  => $options['name'],
+        'password-confirm' => [
+            'password'         => $options['password'],
+            'password-confirm' => $options['password'],
+        ],
+    ]
+);
+$installer->registerVars(
+    Omeka\Installation\Task\AddDefaultSettingsTask::class,
+    [
+        'administrator_email' => $options['email'],
+        'installation_title'  => $options['title'],
+        'time_zone'           => $options['timezone'] ?? 'UTC',
+        'locale'              => $options['locale'] ?? 'en_US',
+    ]
+);
+
+if ($installer->install()) {
+    echo "Installation completed.\n";
+
+} else {
+    echo "Installation failed:\n";
+    foreach ($installer->getErrors() as $err) {
+        echo " - $err\n";
+    }
+    exit(1);
+}


### PR DESCRIPTION
<p>This pull request introduces support for automated configuration of Omeka S using environment variables. It simplifies first-time setup by allowing users to define admin credentials and site details directly from <code inline="">docker-compose.yml</code> or container environments.</p>
<hr>
<h3>Main changes</h3>
<ul>
<li>
<p><strong>Added <code inline="">install_cli.php</code></strong><br>
A new CLI script that handles the initial Omeka S installation via command-line arguments. It checks whether Omeka is already installed and skips reinstallation if tables exist.<br>
<em>The script is idempotent and safe to run multiple times.</em></p>
</li>
<li>
<p><strong>Updated <code inline="">docker-php-entrypoint</code></strong></p>
<ul>
<li>
<p>Detects if all <code inline="">OMEKA_ADMIN_*</code> variables are defined.</p>
</li>
<li>
<p>Waits for MySQL availability using <code inline="">netcat</code>.</p>
</li>
<li>
<p>Executes the CLI installer during container startup.</p>
</li>
</ul>
</li>
<li>
<p><strong>Modified <code inline="">Dockerfile</code></strong></p>
<ul>
<li>
<p>Installs <code inline="">netcat-openbsd</code> to enable TCP availability checks.</p>
</li>
<li>
<p>Copies the new CLI installer into the image.</p>
</li>
</ul>
</li>
<li>
<p><strong>Improved documentation</strong></p>
<ul>
<li>
<p>Added new variables to the <code inline="">README.md</code> under the <code inline="">Environment Variables</code> section.</p>
</li>
<li>
<p>Included usage examples and a clear note explaining that Omeka won't be auto-installed unless the required variables are set.</p>
</li>
</ul>
</li>
<li>
<p><strong>Updated examples</strong></p>
<ul>
<li>
<p>Both <code inline="">docker-compose_local_example.yml</code> and <code inline="">docker-compose_traefik_example.yml</code> now include example values for the new installation-related variables.</p>
</li>
</ul>
</li>
</ul>
<hr>
<h3>New environment variables</h3>

Variable | Description | Required | Default
-- | -- | -- | --
OMEKA_ADMIN_EMAIL | Email for the first Omeka S admin user | ✅ | —
OMEKA_ADMIN_NAME | Name of the admin user | ✅ | —
OMEKA_ADMIN_PASSWORD | Password for the admin user | ✅ | —
OMEKA_SITE_TITLE | Public title of the Omeka S site | ✅ | —
OMEKA_TIMEZONE | (Optional) Timezone, e.g. Atlantic/Canary | ❌ | UTC
OMEKA_LOCALE | (Optional) Locale, e.g. es, en_US | ❌ | en_US


<blockquote>
<p If the <code inline="">OMEKA_ADMIN_</code> variables are not set, Omeka S will not be configured automatically at startup.</p>
</blockquote>
<hr>
<h3>Motivation</h3>
<p>This feature is designed to improve automation and ease deployment of Omeka S in Docker environments—especially for CI/CD pipelines, reproducible development environments, and infrastructure-as-code setups.</p>
</body></html>